### PR TITLE
Refer to 'model server' instead of 'backend'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The AI Digital Kidney Biopsy project builds tools for the analysis of TEM kidney images. Artificial intelligence and computer vision are utilized to measure and calculate properties of the kidney glomerular ultrastructure, for the purposes of aiding in clinical diagnosis and novel drug development.
 
-This repository contains the code for the web client component of the application; the back-end code is in a private repository outside of the hicsail GitHub account.
+This repository contains the code for the web client component of the application; the AI model server code is in a private repository outside of the hicsail GitHub account.
 
 ### Architecture and Deployment
 
 ![Architecture Diagram](docs/architecture.png?raw=true "Architecture Diagram")
 
-At present, the back-end functionality is limited to running segmentation and prediction on an image; this functionality is accessible through a single endpoint `/predict` on the backend server. The inputs are a single image and a pixel size parameter; the outputs are one or more images (mask overlays) along with various metrics and metadata in JSON format. For the initial iteration of the web client, bulk jobs on batches of images are not supported.
+At present, the AI model functionality is limited to running segmentation and prediction on an image; this functionality is accessible through a single endpoint `/predict` on the model server. The inputs are a single image and a pixel size parameter; the outputs are one or more images (mask overlays) along with various metrics and metadata in JSON format. For the initial iteration of the web client, bulk jobs on batches of images are not supported.
 
 Input images are uploaded by the user and stored in S3; outputs from each prediction are likewise stored in S3. Each user owns a subdirectory on the S3 bucket. The directory name is the user's id.
 


### PR DESCRIPTION
Since the Next.js "front-end" server has some "back-end" elements, change the language of the README to not refer to the prediction/AI model/Flask server as "the backend".